### PR TITLE
Set number of workers/cores (Fix #27 & #38)

### DIFF
--- a/src/multiprocess_aams.py
+++ b/src/multiprocess_aams.py
@@ -77,7 +77,7 @@ def main():
     start = time.time()
     # multiprocessing
     COUNT = 0
-    with concurrent.futures.ProcessPoolExecutor() as executor:
+    with concurrent.futures.ProcessPoolExecutor(max_workers = args.workers) as executor:
         # use all commands in list on the function
         results = executor.map(launch_aams_pipeline, commands)
         for res in results:

--- a/src/multiprocess_ams.py
+++ b/src/multiprocess_ams.py
@@ -94,7 +94,7 @@ def main():
     start = time.time()
     # multiprocessing
     COUNT = 0
-    with concurrent.futures.ProcessPoolExecutor() as executor:
+    with concurrent.futures.ProcessPoolExecutor(max_workers = args.workers) as executor:
         # use all commands in list on the function
         results = executor.map(launch_multivcf_extract, commands_multivcf)
         for res in results:
@@ -128,7 +128,7 @@ def main():
     start = time.time()
     # multiprocessing
     COUNT = 0
-    with concurrent.futures.ProcessPoolExecutor() as executor:
+    with concurrent.futures.ProcessPoolExecutor(max_workers = args.workers) as executor:
         # use all commands in list on the function
         results = executor.map(launch_ams_pipeline, commands)
         for res in results:

--- a/src/tools/netmhc_arguments.py
+++ b/src/tools/netmhc_arguments.py
@@ -116,6 +116,7 @@ def check_if_valid_float(parser,arg):
     if not 0 < thresh <= 100:
         parser.error(f"{threshold} not between 0 and 100%")
     return thresh
+    
 
 def netmhc_arguments():
     """
@@ -165,6 +166,10 @@ def netmhc_arguments():
         default="input_pair",
         const="input_pair",
         type=lambda x: arguments_handling.check_if_accepted_str(parser,x))
+    parser.add_argument("-w", "--workers",
+        help="number of workers (cores) for multiprocessing",
+        default=os.cpu_count() // 2,
+        type=lambda x: arguments_handling.check_workers_count(parser, x))
         
     # netMHCpan class
     parser.add_argument("-c", "--class_type",


### PR DESCRIPTION
Adds a new argument `-w` or `--workers` for multiprocessing (both Allo-Count and Allo-Affinity):
- default: half of available cores
- min: 1
- max: all cores

Fix for #27 & #38.