### PR TITLE
fix transcript file in loop

### DIFF
--- a/src/multiprocess_aams.py
+++ b/src/multiprocess_aams.py
@@ -63,7 +63,7 @@ def main():
     # build a list of all commands
     commands = [
         f"python3 aams_pipeline.py -M {MISMATCH}"
-        f" -T {args.transcripts} -E {args.ensembl_transcripts} -P {args.peptides}"
+        f" -T {TRANSCRIPT} -E {args.ensembl_transcripts} -P {args.peptides}"
         f" -R {args.refseq} -n {args.run_name} -l {args.length}"
         f" --el_rank {args.el_rank} -p {Path(MISMATCH).name.split('_')[0]}"
         f" -a {args.hla_typing}"


### PR DESCRIPTION
Fix: used to take the same file instead of looping on `TRANSCRIPTS` list of files.