### PR TITLE
shorten aams cli

### DIFF
--- a/src/aams_pipeline.py
+++ b/src/aams_pipeline.py
@@ -13,14 +13,14 @@ def main():
     """
     # get args from cmd line
     args = netmhc_arguments.netmhc_arguments()
-    str_params = aams_helpers.get_ams_params(args.merged)
+    str_params,mismatches_path = aams_helpers.get_ams_params(args.run_name)
     aams_run_tables,netmhc_dir,aams_path = aams_helpers.create_aams_dependencies(args.run_name)
-    fasta_path,pep_indiv_path = aams_helpers.build_peptides(aams_run_tables,str_params,args)
+    fasta_path,pep_indiv_path = aams_helpers.build_peptides(aams_run_tables,str_params,args,mismatches_path)
     if args.dry_run == False:
         netmhc_out = aams_helpers.run_netmhcpan(fasta_path,netmhc_dir,args)
         netmhc_table = netmhc_tables_handler.handle_netMHCpan(netmhc_out,args)
         netmhc_df, pep_df = aams_helpers.clean_pep_df(netmhc_table, pep_indiv_path,args)
-        mismatch = aams_helpers.merge_netmhc(netmhc_df, pep_df, args.merged, args.el_rank,args.pair,
+        mismatch = aams_helpers.merge_netmhc(netmhc_df, pep_df, args.mismatches, mismatches_path, args.el_rank,args.pair,
                                             aams_path,aams_run_tables,str_params, args.class_type)
         print(mismatch)
         return 0

--- a/src/multiprocess_aams.py
+++ b/src/multiprocess_aams.py
@@ -60,9 +60,9 @@ def main():
 
     # build a list of all commands
     commands = [
-        f"python3 aams_pipeline.py -M {MISMATCH}"
-        f" -T {TRANSCRIPT} -E {args.ensembl_transcripts} -P {args.peptides}"
-        f" -R {args.refseq} -n {args.run_name} -l {args.length}"
+        f"python3 aams_pipeline.py"
+        f" -M {MISMATCH} -T {TRANSCRIPT}"
+        f" -n {args.run_name} -d {args.ensembl_path}"
         f" --el_rank {args.el_rank} -p {Path(MISMATCH).name.split('_')[0]}"
         f" -a {args.hla_typing} {'--dry_run' if args.dry_run else ''}"
         for (MISMATCH, TRANSCRIPT) in zip(MISMATCHES,TRANSCRIPTS)

--- a/src/tools/netmhc_arguments.py
+++ b/src/tools/netmhc_arguments.py
@@ -129,28 +129,20 @@ def netmhc_arguments():
         usage="python %(prog)s [options]",
         description="Compute the AAMS for a pair of individuals"
         )
-    parser.add_argument("-M", "--merged",
-        help="path of the pair merged file",
+    parser.add_argument("-M", "--mismatches",
+        help=argparse.SUPPRESS,
         action=arguments_handling.UniqueStore,
-        required=True,
-        type=lambda x: check_if_existing_path(parser,x))
+        default="",
+        const="",
+        required=False)
     parser.add_argument("-T", "--transcripts",
-        help="path of the pair transcripts file",
+        help=argparse.SUPPRESS,
         action=arguments_handling.UniqueStore,
-        required=True,
-        type=lambda x: check_if_existing_path(parser,x))
-    parser.add_argument("-E", "--ensembl_transcripts",
-        help="path of the ensembl transcripts file",
-        action=arguments_handling.UniqueStore,
-        required=True,
-        type=lambda x: check_if_existing_path(parser,x))
-    parser.add_argument("-P", "--peptides",
-        help="path of the ensembl peptides file",
-        action=arguments_handling.UniqueStore,
-        required=True,
-        type=lambda x: check_if_existing_path(parser,x))
-    parser.add_argument("-R", "--refseq",
-        help="path of the ensembl refseq transcripts file",
+        default="",
+        const="",
+        required=False)
+    parser.add_argument("-d", "--ensembl_path",
+        help="path of directory of Ensembl files",
         action=arguments_handling.UniqueStore,
         required=True,
         type=lambda x: check_if_existing_path(parser,x))
@@ -158,6 +150,8 @@ def netmhc_arguments():
         help="name of the ams pipeline ran previously",
         action=arguments_handling.UniqueStore,
         required=True,
+        default="run",
+        const="run",
         type=lambda x: check_if_existing_run_name(parser,x))
     parser.add_argument("-p", "--pair", # automated pair naming for multiprocess
         help=argparse.SUPPRESS,


### PR DESCRIPTION
Gets mismatch & transcript table from the run name argument instead of specifying the full path.
Same for Ensembl files: we just need the specify the directory (new arg `-d`).