### PR TITLE
Fix imputation filtering bug

### DIFF
--- a/src/tools/ams_helpers.py
+++ b/src/tools/ams_helpers.py
@@ -66,9 +66,10 @@ def handle_overwrite(args):
 def write_log(run_path, args):
     with open(os.path.join(run_path, "run.log"), "w") as f:
         f.write(f"Run_name: {args.run_name}\n")
-        f.write(f"Orientation: {args.orientation}\n")
         f.write(f"Donor: {args.donor}\n")
         f.write(f"Recipient: {args.recipient}\n")
+        f.write(f"Orientation: {args.orientation}\n")
+        f.write(f"Imputation: {args.imputation}\n")
         f.write(f"Command: {' '.join(sys.argv)}\n")
         f.write(f"Timestamp: {time.strftime('%Y-%m-%d %H:%M:%S')}\n")
     

--- a/src/tools/cleavage.py
+++ b/src/tools/cleavage.py
@@ -6,12 +6,11 @@ from tools import aams_helpers
 
 def pickle_parsing(str_params, args):
     # get donor or recipient name from orientation in log file
-    log_file = os.path.join(f"../output/runs/{args.run_name}/run.log")
-    orientation = aams_helpers.read_log_field(log_file, "Orientation")
+    orientation = aams_helpers.read_log_field(args, "Orientation")
     if orientation == "dr":
-        sample = aams_helpers.read_log_field(log_file, "Donor").split("/")[-1].split(".")[0]
+        sample = aams_helpers.read_log_field(args, "Donor").split("/")[-1].split(".")[0]
     if orientation == "rd":
-        sample = aams_helpers.read_log_field(log_file, "Recipient").split("/")[-1].split(".")[0]
+        sample = aams_helpers.read_log_field(args, "Recipient").split("/")[-1].split(".")[0]
     
     # removes base_length from str_params
     str_params_split = "_".join(str_params.split("_")[i] for i in [0, 1, 2, 4])


### PR DESCRIPTION
Bug: filtering mismatches when `aa_REF` was missing (filtering since length 0 in this case).
Fix: in "imputation mode" only, adds the `aa_REF` by parsing it from the `Amino_acids` column based on VCF annotated file.