### PR TITLE
Add frameshift peptides generation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,10 @@ To install the VEP command line tool, follow the installation tutorial available
 Run the following command to annotate your `.VCF` file(s) with VEP.
 
 **All specified options are mandatory, with the exception of the assembly if you only downloaded one cache file.**  
+
+
 ```
-	vep --fork 4 --cache --assembly <GRChXX> --offline --af_gnomade -i <FILE-TO-ANNOTATE>.vcf -o <ANNOTATED-FILE>.vcf --coding_only --pick_allele --use_given_ref --vcf 
+vep --fork 4 --cache --assembly <GRChXX> --offline --af_gnomade -i <FILE-TO-ANNOTATE>.vcf -o <ANNOTATED-FILE>.vcf --coding_only --pick_allele --use_given_ref --vcf
 ```
 
 Where:
@@ -179,6 +181,23 @@ This command line works for individual `.VCF` files or joint `.VCF` files, wheth
 Run this command for every file you want to input in AlloPipe.
 
 **Once the variant-annotation of your file(s) is(are) complete, you are now ready to run your first AlloPipe run!**
+
+<br/>
+
+Note: if you want to take into account frameshift neoantigens peptide generation in the af-AMS, you need to add the [Frameshift plugin](https://github.com/griffithlab/pVACtools/blob/0c05768b7b9b317eebdeeb2a7a178b8a12c880d6/pvactools/tools/pvacseq/VEP_plugins/Frameshift.pm) from the [pVACtools](https://github.com/griffithlab/pVACtools) software to your VEP installation.
+
+```
+mv Frameshift.pm ~/.vep/Plugins
+```
+
+You should then add these options to the VEP command:
+
+```
+--plugin Frameshift --dir_plugins <PLUGIN-PATH>
+```
+
+with ```<PLUGIN-PATH>``` being the path to your VEP plugins directory.
+
 
 <br/>
 
@@ -244,6 +263,9 @@ More detailed help can be obtained with the ``--help`` switch:
 ```
 python ams_pipeline.py --help
 ```  
+
+
+For instance, you can generate frameshift neoantigen candidates in the second step (Allo‑Affinity) with the dedicated mode when running Allo‑Count by adding the `--frameshift` option to the Allo-Count run. Note: you need to have installed the VEP `Frameshift` plugin.
 
 <br/>
 
@@ -319,11 +341,12 @@ This table gives you information on the mismatched positions. For each type of i
 - **TYPE_{x, y} (str):** type of genotype (homozygous, heterozygous)
 
 3. **VEP information**: 
-- **consequences_{x, y} (int)**: Count of each consequence type (i.e. framshift indel, missense variant, ...)
+- **consequences_{x, y} (int)**: Count of each consequence type (i.e. frameshift indel, missense variant, ...)
 - **transcripts_{x, y} (str)**: Transcripts recorded for the variant
 - **genes_{x, y} (str)**: Genes recorded for the variant
 - **aa_REF, aa_ALT (str)**: Amino-acid for REF and ALT alleles for the variant
 - **gnomADe_AF_{x, y} (float)**: Frequency of existing variant in gnomAD exomes combined population
+- **Frameshift_sequence_{x, y} (str):** Frameshift sequences annotated by VEP (if `--frameshift` is activated, empty otherwise)
 - **aa_ref_indiv_{x, y}, aa_alt_indiv_{x, y} (str)**: REF and ALT amino acids recorded for the sample (x and y)
 - **aa_indiv_{x, y} (str)**: REF and ALT amino acids combined in one column
 
@@ -505,6 +528,7 @@ Before running the Allo-Affinity module, unzip the files corresponding to your a
 ```
 
 <br/>
+
 If you want to run the cleaved peptide prediction, add the `--cleavage` switch:
 
 ```

--- a/src/multiprocess_ams.py
+++ b/src/multiprocess_ams.py
@@ -118,7 +118,7 @@ def main():
     f"--homozygosity_thr {args.homozygosity_thr} --gnomad_af {args.gnomad_af} "
     f"--min_gq {args.min_gq} --base_length {args.base_length} "
     f"--run_name {q(args.run_name)} --pair P{pair_number:0{leading_zeros_number}d} "
-    f"--output_dir {q(args.output_dir)}"
+    f"--output_dir {q(args.output_dir)}{' --frameshift' if args.frameshift else ''}"
 #   Doesn't take into account -wc
 #    f"-wc --wc_donor {args.wc_donor} --wc_recipient {args.wc_recipient}"
     for pair_number, (path_donor, path_recipient) in enumerate(path_couples, 1)

--- a/src/tools/aams_helpers.py
+++ b/src/tools/aams_helpers.py
@@ -194,6 +194,7 @@ def add_pep_seq(transcripts_pair, peptides_ensembl, cleavage_mode=False):
                 "Sequence_nt",
                 "Peptide_id",
                 "Sequence_aa",
+                "Frameshift_sequence",
                 "Amino_acids",
                 "aa_ref_indiv_x",
                 "aa_alt_indiv_x",
@@ -308,7 +309,81 @@ def peptide_seg(peptide, pep_size):
     return hla_peptides
 
 
-def get_peptides_ref(transcripts_pair, pep_size=None, cleavage_mode=False):
+def get_frameshift_peptides(transcripts_frameshift, pep_size):
+    """
+    Build reference and alternative peptides for frameshift variants.
+    """
+
+    # Keep rows with a valid protein position (start from first position if interval)
+    transcripts_frameshift = transcripts_frameshift.dropna(subset=["Protein_position"])
+    transcripts_frameshift["Protein_position"] = (
+        transcripts_frameshift["Protein_position"]
+        .astype(str)
+        .str.split("-")
+        .str[0]
+        .astype(float)
+        .astype(int)
+    )
+
+    def build_peptide_alt(row):
+        """
+        Build alternative peptide around the same position using the frameshift sequence.
+        No additional mutation is applied: 'Frameshift_sequence' is the final sequence.
+        Sliding window is kept on the left side (pep_size upstream),
+        and the peptide is extended until the end of the protein.
+        """
+        seq_alt = row["Frameshift_sequence"]
+        if pd.isna(seq_alt) or str(seq_alt) == "nan":
+            return None
+        pos = row["Protein_position"]
+        # Convert to 0-based index
+        pos0 = pos - 1
+        # Start pep_size upstream of the position (or at 0)
+        start = max(0, pos0 - pep_size + 1)
+        # Return from start to the end of the protein
+        return seq_alt[start:]
+
+    transcripts_frameshift["peptide"] = transcripts_frameshift.apply(
+        build_peptide_alt, axis=1
+    )
+    # No reference peptide is generated for frameshift cases.
+    # Keep an empty placeholder to preserve downstream schema.
+    transcripts_frameshift["peptide_REF"] = ""
+
+    # Drop rows without valid peptides and remove duplicates
+    transcripts_frameshift = transcripts_frameshift.dropna(
+        subset=["peptide"]
+    )
+    transcripts_frameshift = transcripts_frameshift.drop_duplicates(
+        ["CHROM", "POS", "Gene_id", "peptide"]
+    )
+
+    # For frameshift variants, only ALT peptides are generated.
+    # Keep REF peptide lists empty to preserve downstream schema.
+    transcripts_frameshift["hla_peptides_REF"] = transcripts_frameshift["peptide"].apply(
+        lambda _: []
+    )
+    transcripts_frameshift["hla_peptides"] = transcripts_frameshift["peptide"].apply(
+        lambda x: peptide_seg(x, pep_size)
+    )
+
+    # Align columns with the non-frameshift output
+    return transcripts_frameshift[
+        [
+            "CHROM",
+            "POS",
+            "Gene_id",
+            "Transcript_id",
+            "Peptide_id",
+            "peptide_REF",
+            "peptide",
+            "hla_peptides_REF",
+            "hla_peptides",
+        ]
+    ]
+
+
+def get_peptides_ref(transcripts_pair, pep_size=None, cleavage_mode=False, frameshift_mode=False):
     transcripts_pair["aa_REF"] = transcripts_pair["aa_REF"].str.split(",")
     transcripts_pair = transcripts_pair.explode("aa_REF")
 
@@ -323,7 +398,14 @@ def get_peptides_ref(transcripts_pair, pep_size=None, cleavage_mode=False):
             (transcripts_pair["aa_REF"].str.len() <= 3)
         ]
 
-        # exclude frameshift and stop variants
+        # Initialize frameshift container so it is always defined
+        transcripts_frameshift = pd.DataFrame()
+
+        # Exclude splice and stop variants; keep frameshift apart if enabled
+        if frameshift_mode:
+            mask_frameshift = transcripts_pair["Consequence"].str.contains("frameshift")
+            transcripts_frameshift = transcripts_pair[mask_frameshift].copy()
+
         transcripts_pair = transcripts_pair[
             ~(
                 transcripts_pair["Consequence"].str.contains("frameshift|stop|splice")
@@ -385,11 +467,20 @@ def get_peptides_ref(transcripts_pair, pep_size=None, cleavage_mode=False):
             ["CHROM", "POS", "Gene_id", "peptide_REF", "peptide"], as_index=False
         )[["Transcript_id", "Peptide_id"]].agg("first")
         transcripts_reduced["hla_peptides_REF"] = transcripts_reduced["peptide_REF"].apply(
-            lambda x: peptide_seg(x, pep_size)
-        )
+            lambda x: peptide_seg(x, pep_size))
         transcripts_reduced["hla_peptides"] = transcripts_reduced["peptide"].apply(
             lambda x: peptide_seg(x, pep_size)
         )
+        
+        # Handle frameshift variants that were split earlier, only if frameshift_mode is enabled
+        if frameshift_mode and not transcripts_frameshift.empty:
+            frameshift_reduced = get_frameshift_peptides(transcripts_frameshift, pep_size)
+            # Align columns and concatenate
+            frameshift_reduced = frameshift_reduced[transcripts_reduced.columns]
+            transcripts_reduced = pd.concat(
+                [transcripts_reduced, frameshift_reduced], ignore_index=True
+            )
+
         return transcripts_reduced
 
 
@@ -534,7 +625,13 @@ def build_peptides(aams_run_tables=None, str_params=None, args=None, mismatches_
         # get imputation mode in log file
         imputation = read_log_field(args, "Imputation")
         transcripts_pair = aa_ref(transcripts_pair, imputation)
-    
+
+        # get frameshift mode in log file
+        frameshift_mode = read_log_field(args, "Frameshift") == "True"
+    else:
+        # frameshift handling is disabled in cleavage mode
+        frameshift_mode = False
+
     # get pep seq on long format table
     transcripts_pair = add_pep_seq(transcripts_pair, peptides_ensembl, cleavage_mode)
 
@@ -542,9 +639,9 @@ def build_peptides(aams_run_tables=None, str_params=None, args=None, mismatches_
         transcripts_pair.to_csv(os.path.join(
             aams_run_tables,
             f"{args.pair + '_' if args.pair else ''}{args.run_name}_full.tsv"), sep="\t", index=False)
-        
-        transcripts_reduced = get_peptides_ref(transcripts_pair, args.length, cleavage_mode)
-        
+
+        transcripts_reduced = get_peptides_ref(transcripts_pair, args.length, cleavage_mode, frameshift_mode)
+
         pep_base_name = f"{args.pair + '_' if args.pair else ''}{args.run_name}_pep_df_{str_params}"
         # duplicate with .pkl below
         pep_indiv_path = os.path.join(aams_run_tables, f"{pep_base_name}.tsv")
@@ -565,7 +662,7 @@ def build_peptides(aams_run_tables=None, str_params=None, args=None, mismatches_
                 f"{args.pair + '_' if args.pair else ''}{args.run_name}_fasta.fa")
         return fasta_path, pep_indiv_path, ens_transcripts, peptides_ensembl, refseq_file, pair_print
     else:
-        transcripts_pair = get_peptides_ref(transcripts_pair, args.length, cleavage_mode)
+        transcripts_pair = get_peptides_ref(transcripts_pair, args.length, cleavage_mode, frameshift_mode)
         mismatches_df = read_mismatches(args, mismatches_path)
         return mismatches_df, transcripts_pair, peptides_ensembl, pair_print
 

--- a/src/tools/ams_helpers.py
+++ b/src/tools/ams_helpers.py
@@ -75,6 +75,7 @@ def write_log(run_logs, args):
         f.write(f"Recipient: {args.recipient}\n")
         f.write(f"Orientation: {args.orientation}\n")
         f.write(f"Imputation: {args.imputation}\n")
+        f.write(f"Frameshift: {args.frameshift}\n")
         f.write(f"Command: {' '.join(sys.argv)}\n")
         f.write(f"Output_dir: {args.output_dir}\n")
         f.write(f"Timestamp: {time.strftime('%Y-%m-%d %H:%M:%S')}\n")
@@ -451,9 +452,9 @@ def prepare_indiv_df(run_tables, vcf_path_indiv, args, consequences_path, format
     """
     # check file extension to select the appropriate parsing function
     if vcf_path_indiv.split(".")[-1] == "vcf":
-        df_indiv, vep_indices = parsing_functions.vcf_vep_parser(vcf_path_indiv)
+        df_indiv, vep_indices = parsing_functions.vcf_vep_parser(vcf_path_indiv, args.frameshift)
     else:
-        df_indiv, vep_indices = parsing_functions.gzvcf_vep_parser(vcf_path_indiv)
+        df_indiv, vep_indices = parsing_functions.gzvcf_vep_parser(vcf_path_indiv, args.frameshift)
     # get read counts info from patient column
     df_indiv, subset = get_read_counts(
         df_indiv, vcf_path_indiv, args.min_ad, args.min_gq, args.base_length

--- a/src/tools/arguments_handling.py
+++ b/src/tools/arguments_handling.py
@@ -207,6 +207,11 @@ def arguments(from_filePair : bool = False):
         choices=["imputation", "no-imputation"],
     )
     parser.add_argument(
+        "--frameshift",
+        help="enable frameshift neoantigen peptide generation for downstream AAMS (requires VEP Frameshift plugin annotation)",
+        action="store_true",
+    )
+    parser.add_argument(
         "--min_dp",
         help="minimal accepted depth per position",
         nargs="?",

--- a/src/tools/parsing_functions.py
+++ b/src/tools/parsing_functions.py
@@ -28,7 +28,7 @@ class VepIndices:
                     codons (int): index of the codons field in VEP
                     gnomad (int): index of the frequency of existing variant in gnomAD exomes combined population in VEP
     """
-    def __init__(self, consequence, gene, transcript, cdna, cds, prot, aa, codons, gnomad):
+    def __init__(self, consequence, gene, transcript, cdna, cds, prot, aa, codons, gnomad, frameshift):
         self.consequence = consequence
         self.gene = gene
         self.transcript = transcript
@@ -38,9 +38,11 @@ class VepIndices:
         self.aa = aa
         self.codons = codons
         self.gnomad = gnomad
+        # May be None if the VEP annotation does not include FrameshiftSequence
+        self.frameshift = frameshift
 
 
-def vcf_vep_parser(vcf_path):
+def vcf_vep_parser(vcf_path, frameshift_mode):
     """
     Returns a dataframe of the parsed VCF file containing VEP information and the VepIndices object containing the indices
     Parameters :
@@ -68,6 +70,8 @@ def vcf_vep_parser(vcf_path):
                 aa_index = match.group(1).split("|").index("Amino_acids")
                 codons_index = match.group(1).split("|").index("Codons")
                 gnomad_index = match.group(1).split("|").index("gnomADe_AF")
+                # FrameshiftSequence is optional: handle absence
+                frameshift_index = _get_frameshift_index(match.group(1).split("|"), frameshift_mode)
                 matched = True
             # get row number and break the loop if column names are found
             if "#CHROM" in line:
@@ -86,7 +90,8 @@ def vcf_vep_parser(vcf_path):
         prot_index,
         aa_index,
         codons_index,
-        gnomad_index
+        gnomad_index,
+        frameshift_index,
     )
     return (
         pd.read_csv(vcf_path, header=header_index, dtype="str", sep="\t"),
@@ -94,7 +99,7 @@ def vcf_vep_parser(vcf_path):
     )
 
 
-def gzvcf_vep_parser(vcf_path):
+def gzvcf_vep_parser(vcf_path, frameshift_mode):
     """
     Returns a dataframe of the parsed gzipped VCF file containing VEP information and the VepIndices object containing the indices
     Parameters :
@@ -127,6 +132,8 @@ def gzvcf_vep_parser(vcf_path):
             aa_index = match.group(1).decode("utf-8").split("|").index("Amino_acids")
             codons_index = match.group(1).decode("utf-8").split("|").index("Codons")
             gnomad_index = match.group(1).decode("utf-8").split("|").index("gnomADe_AF")
+            # FrameshiftSequence is optional: handle absence
+            frameshift_index = _get_frameshift_index(match.group(1).decode("utf-8").split("|"), frameshift_mode)
         # get row number and break the loop if column names are found
         if b"#CHROM" in line:
             header_index = count
@@ -144,11 +151,26 @@ def gzvcf_vep_parser(vcf_path):
         aa_index,
         codons_index,
         gnomad_index,
+        frameshift_index,
     )
     return (
         pd.read_csv(vcf_path, header=header_index, dtype="str", sep="\t"),
         vep_indices,
     )
+
+
+def _get_frameshift_index(fields, frameshift_mode):
+    """Get FrameshiftSequence index from VEP fields, or None if absent and frameshift_mode is off."""
+    try:
+        return fields.index("FrameshiftSequence")
+    except ValueError:
+        if frameshift_mode:
+            sys.exit(
+                "Frameshift mode is enabled but 'FrameshiftSequence' annotation "
+                "is missing from the VEP input file. "
+                "Please re-run VEP with the Frameshift plugin enabled."
+            )
+        return None
 
 
 def extract_aa_from_vep(df_infos, vep_indices):
@@ -191,6 +213,20 @@ def extract_aa_from_vep(df_infos, vep_indices):
         .groupby(level=0)
         .apply(lambda x: x.dropna().unique().tolist())
     )
+    # get frameshift sequence using found index in the vep line parser (optional)
+    if vep_indices.frameshift is not None:
+        frameshift_subset = vep_split_df[list(range(len_expand))].apply(
+            lambda x: x.str.split("|").str[vep_indices.frameshift]
+        )
+        frameshift_subset["Frameshift_sequence"] = (
+            frameshift_subset.stack()
+            .groupby(level=0)
+            .apply(lambda x: x.dropna().unique().tolist())
+        )
+        frameshift_series = frameshift_subset["Frameshift_sequence"].str.join(",")
+    else:
+        # If FrameshiftSequence is not annotated by VEP, keep an empty string
+        frameshift_series = pd.Series([""] * len(selected_df), index=selected_df.index)
     # get aa ref and aa alt from VEP info
     aa_ref_subset = vep_split_df[list(range(len_expand))].apply(
         lambda x: x.str.split("|").str[vep_indices.aa].str.split("/").str[0]
@@ -217,6 +253,7 @@ def extract_aa_from_vep(df_infos, vep_indices):
         .groupby(level=0)
         .apply(lambda x: x.dropna().unique().tolist())
     )
+    selected_df["Frameshift_sequence"] = frameshift_series
     selected_df["transcripts"] = transcript_subset["transcript"].str.join(",")
     selected_df["genes"] = gene_subset["gene"].str.join(",")
     selected_df["aa_REF"] = aa_ref_subset["aa"].str.join(",")

--- a/src/tools/table_operations.py
+++ b/src/tools/table_operations.py
@@ -129,31 +129,35 @@ def build_transcripts_table_indiv(vep_table_path, merged_ams, vep_indices, indiv
     # explode the dataframe on the INFO column (VEP information only)
     vep_table = vep_table.explode("INFO", ignore_index=True)
     # keep the columns of interest
-    vep_table[
-        [
-            "Consequence",
-            "Gene_id",
-            "Transcript_id",
-            "cDNA_position",
-            "CDS_position",
-            "Protein_position",
-            "Amino_acids",
-            "Codons",
-            "gnomADe_AF"
-        ]
-    ] = vep_table["INFO"].str.split("|", expand=True)[
-        [
-            vep_indices.consequence,
-            vep_indices.gene,
-            vep_indices.transcript,
-            vep_indices.cdna,
-            vep_indices.cds,
-            vep_indices.prot,
-            vep_indices.aa,
-            vep_indices.codons,
-            vep_indices.gnomad
-        ]
+    info_split = vep_table["INFO"].str.split("|", expand=True)
+    base_indices = [
+        vep_indices.consequence,
+        vep_indices.gene,
+        vep_indices.transcript,
+        vep_indices.cdna,
+        vep_indices.cds,
+        vep_indices.prot,
+        vep_indices.aa,
+        vep_indices.codons,
+        vep_indices.gnomad,
     ]
+    base_cols = [
+        "Consequence",
+        "Gene_id",
+        "Transcript_id",
+        "cDNA_position",
+        "CDS_position",
+        "Protein_position",
+        "Amino_acids",
+        "Codons",
+        "gnomADe_AF",
+    ]
+    vep_table[base_cols] = info_split[base_indices]
+    # Frameshift_sequence is optional
+    if vep_indices.frameshift is not None:
+        vep_table["Frameshift_sequence"] = info_split[vep_indices.frameshift]
+    else:
+        vep_table["Frameshift_sequence"] = ""
     # return the dataframe without the INFO column
     return vep_table.drop("INFO", axis=1)
 
@@ -187,6 +191,7 @@ def build_transcripts_table(transcripts_donor, transcripts_recipients):
             "Codons",
             "gnomADe_AF",
             "diff",
+            "Frameshift_sequence",
         ],
     )
     # drop duplicates
@@ -205,6 +210,7 @@ def build_transcripts_table(transcripts_donor, transcripts_recipients):
             "Codons",
             "gnomADe_AF",
             "diff",
+            "Frameshift_sequence",
         ],
         as_index=False,
     )["Transcript_id"].agg(lambda x: x.tolist())


### PR DESCRIPTION
- will always generate frameshift fields in different tables but populate only if option activated
- option has to be activated in the AMS run (`--frameshift`), then read from log file in AAMS
- requires the Frameshift plugin from pVACtools but allow to run in regular mode without this specific annotation
- raise error if mode is activated but specific annotation missing