### PR TITLE
Add Allo-affinity logging

### DIFF
--- a/src/aams_pipeline.py
+++ b/src/aams_pipeline.py
@@ -17,13 +17,14 @@ def main():
     aams_run_tables, netmhc_dir, aams_path, netchop_dir = aams_helpers.create_aams_dependencies(
         args.run_name, args.output_dir
     )
+    log_file = aams_helpers.append_log(args)
     fasta_path, pep_indiv_path, ens_transcripts, peptides_ensembl, refseq_file, pair_print = aams_helpers.build_peptides(
-        aams_run_tables, str_params, args, mismatches_path, cleavage_mode=False
+        aams_run_tables, str_params, args, log_file, mismatches_path, cleavage_mode=False
     )
     if args.cleavage == True:
-        pickle_df = cleavage.pickle_parsing(str_params, args)
+        pickle_df = cleavage.pickle_parsing(str_params, args, log_file)
         mismatches_df, transcripts_pair, peptides_ensembl, pair_print = aams_helpers.build_peptides(
-            aams_run_tables, str_params, args, mismatches_path, mismatches_df=pickle_df, cleavage_mode=args.cleavage,
+            aams_run_tables, str_params, args, log_file, mismatches_path, mismatches_df=pickle_df, cleavage_mode=args.cleavage,
             ens_transcripts=ens_transcripts, peptides_ensembl=peptides_ensembl, refseq_file=refseq_file
         )
         chop_table, chop_table_path = cleavage.netchop_table_prep(mismatches_df, transcripts_pair, peptides_ensembl, args, netchop_dir)

--- a/src/tools/aams_helpers.py
+++ b/src/tools/aams_helpers.py
@@ -7,6 +7,7 @@ import os
 import sys
 import shutil
 import glob
+import time
 from pathlib import Path
 import numpy as np
 import pandas as pd
@@ -37,7 +38,7 @@ def create_aams_dependencies(ams_run_directory, output_dir):
     return aams_run_tables, netmhc_dir, aams_path, netchop_dir
 
 
-def read_log_field(args, field_name):
+def append_log(args):
     log_file = os.path.join(
         args.output_dir,
         "runs",
@@ -45,6 +46,18 @@ def read_log_field(args, field_name):
         "logs",
         f"{args.pair + '_' if args.pair else ''}run.log",
     )
+    # Keep AMS log part to (over)write only AAMS lines
+    with open(log_file, "r") as f:
+        lines = [l for l in f if not l.startswith(("AAMS_command:", "AAMS_timestamp:"))]
+    # AAMS lines written or modified
+    lines.append(f"AAMS_command: {' '.join(sys.argv)}\n")
+    lines.append(f"AAMS_timestamp: {time.strftime('%Y-%m-%d %H:%M:%S')}\n")
+    with open(log_file, "w") as f:
+        f.writelines(lines)
+    return log_file
+
+
+def read_log_field(log_file, field_name):
     with open(log_file) as f:
         for line in f:
             if line.startswith(f"{field_name}:"):
@@ -563,7 +576,7 @@ def get_ams_params(run_name, output_dir):
     return str_params,mismatches_path
 
 
-def build_peptides(aams_run_tables=None, str_params=None, args=None, mismatches_path=None, mismatches_df=None,
+def build_peptides(aams_run_tables=None, str_params=None, args=None, log_file=None, mismatches_path=None, mismatches_df=None,
                    cleavage_mode=False, ens_transcripts=None, peptides_ensembl=None, refseq_file=None):
     # pair ID for print in multiprocess mode
     pair_print = f"[{args.pair}] " if args.pair else ""
@@ -625,11 +638,11 @@ def build_peptides(aams_run_tables=None, str_params=None, args=None, mismatches_
 
     if not cleavage_mode:
         # get imputation mode in log file
-        imputation = read_log_field(args, "Imputation")
+        imputation = read_log_field(log_file, "Imputation")
         transcripts_pair = aa_ref(transcripts_pair, imputation)
 
         # get frameshift mode in log file
-        frameshift_mode = read_log_field(args, "Frameshift") == "True"
+        frameshift_mode = read_log_field(log_file, "Frameshift") == "True"
     else:
         # frameshift handling is disabled in cleavage mode
         frameshift_mode = False

--- a/src/tools/aams_helpers.py
+++ b/src/tools/aams_helpers.py
@@ -50,7 +50,7 @@ def append_log(args):
     with open(log_file, "r") as f:
         lines = [l for l in f if not l.startswith(("AAMS_command:", "AAMS_timestamp:"))]
     # AAMS lines written or modified
-    lines.append(f"AAMS_command: {' '.join(sys.argv)}\n")
+    lines.append(f"AAMS_command: {' '.join([sys.executable] + sys.argv)}\n")
     lines.append(f"AAMS_timestamp: {time.strftime('%Y-%m-%d %H:%M:%S')}\n")
     with open(log_file, "w") as f:
         f.writelines(lines)

--- a/src/tools/ams_helpers.py
+++ b/src/tools/ams_helpers.py
@@ -77,7 +77,7 @@ def write_log(run_logs, args):
         f.write(f"Imputation: {args.imputation}\n")
         f.write(f"Frameshift: {args.frameshift}\n")
         f.write(f"Output_dir: {args.output_dir}\n")
-        f.write(f"AMS_command: {' '.join(sys.argv)}\n")
+        f.write(f"AMS_command: {' '.join([sys.executable] + sys.argv)}\n")
         f.write(f"AMS_timestamp: {time.strftime('%Y-%m-%d %H:%M:%S')}\n")
     
 

--- a/src/tools/ams_helpers.py
+++ b/src/tools/ams_helpers.py
@@ -68,17 +68,17 @@ def handle_overwrite(args):
 
 
 def write_log(run_logs, args):
-    log_name = f"{args.pair + '_' if args.pair else ''}run.log"
-    with open(os.path.join(run_logs, log_name), "w") as f:
+    log_file = f"{args.pair + '_' if args.pair else ''}run.log"
+    with open(os.path.join(run_logs, log_file), "w") as f:
         f.write(f"Run_name: {args.run_name}\n")
         f.write(f"Donor: {args.donor}\n")
         f.write(f"Recipient: {args.recipient}\n")
         f.write(f"Orientation: {args.orientation}\n")
         f.write(f"Imputation: {args.imputation}\n")
         f.write(f"Frameshift: {args.frameshift}\n")
-        f.write(f"Command: {' '.join(sys.argv)}\n")
         f.write(f"Output_dir: {args.output_dir}\n")
-        f.write(f"Timestamp: {time.strftime('%Y-%m-%d %H:%M:%S')}\n")
+        f.write(f"AMS_command: {' '.join(sys.argv)}\n")
+        f.write(f"AMS_timestamp: {time.strftime('%Y-%m-%d %H:%M:%S')}\n")
     
 
 #############

--- a/src/tools/cleavage.py
+++ b/src/tools/cleavage.py
@@ -12,13 +12,13 @@ def _get_vep_indices_from_vcf(vcf_path, frameshift_mode):
     return vep_indices
 
 
-def pickle_parsing(str_params, args):
+def pickle_parsing(str_params, args, log_file):
     # get donor or recipient vcf path from orientation in log file
-    orientation = aams_helpers.read_log_field(args, "Orientation")
+    orientation = aams_helpers.read_log_field(log_file, "Orientation")
     if orientation == "dr":
-        vcf_path_indiv = aams_helpers.read_log_field(args, "Donor")
+        vcf_path_indiv = aams_helpers.read_log_field(log_file, "Donor")
     elif orientation == "rd":
-        vcf_path_indiv = aams_helpers.read_log_field(args, "Recipient")
+        vcf_path_indiv = aams_helpers.read_log_field(log_file, "Recipient")
 
     sample = os.path.basename(vcf_path_indiv).split(".")[0]
 


### PR DESCRIPTION
- In the same file as Allo-count logging
- If Allo-affinity ran several times, overwrites only allo-affinity part of the log to keep the last occurrence